### PR TITLE
Corrigindo bug que player não tocava os lados do canvas

### DIFF
--- a/finish.js
+++ b/finish.js
@@ -3,10 +3,8 @@ var finishState = {
     new BackgroundControl().create();
 
     var labelOptions = { font: "30px Arial", fill: "#ffffff" };
-    labelScore = game.add.text(20, 180, 'Press SPACEBAR to Play', labelOptions);
-
-    var scoreLabel = { font: "30px Arial", fill: "#ffffff" };
-    scoreLabel = game.add.text(170, 230, score, labelOptions);
+    game.add.text(20, 180, 'Press SPACEBAR to Play', labelOptions);
+    game.add.text(170, 230, score, labelOptions);
 
     var spaceBarKey = game.input.keyboard.addKey(Phaser.Keyboard.SPACEBAR);
     spaceBarKey.onDown.addOnce(this.startGame, this);

--- a/load.js
+++ b/load.js
@@ -2,8 +2,8 @@ var loadState = {
   preload: function() {
     new BackgroundControl().create();
 
-    var options = { font: '30px Courier', fill: '#ffffff' };
-    var loadingLabel = game.add.text(80, 150, 'loading...', options);
+    var labelOptions = { font: '30px Courier', fill: '#ffffff' };
+    game.add.text(80, 150, 'loading...', labelOptions);
 
     game.load.image('sky', 'assets/sky.png');
     game.load.image('ground', 'assets/platform.png');

--- a/menu.js
+++ b/menu.js
@@ -3,7 +3,7 @@ var menuState = {
     new BackgroundControl().create();
 
     var labelOptions = { font: "30px Arial", fill: "#ffffff" };
-    labelScore = game.add.text(20, 220, 'Press SPACEBAR to Play', labelOptions);
+    game.add.text(20, 220, 'Press SPACEBAR to Play', labelOptions);
 
     var spaceBarKey = game.input.keyboard.addKey(Phaser.Keyboard.SPACEBAR);
     spaceBarKey.onDown.addOnce(this.startGame, this);

--- a/play.js
+++ b/play.js
@@ -10,10 +10,10 @@ var playState = {
 
     player = game.add.sprite((game.world.width / 2) - 40, game.world.height - 65, 'player');
     player.scale.setTo(0.7);
+    game.physics.arcade.enable(player);
+    player.body.collideWorldBounds = true;
 
     ball = game.add.sprite((game.world.width / 2) - 40, 0, 'ball');
-
-    game.physics.arcade.enable(player);
     game.physics.arcade.enable(ball);
 
     ball.body.gravity.y = 500;

--- a/play.js
+++ b/play.js
@@ -1,4 +1,4 @@
-var cursors, player, ball, scoreLabel, messageLabel;
+var cursors, player, ball, scoreLabel;
 var score = 0;
 var PLAYER_SPEED = 300;
 
@@ -23,7 +23,7 @@ var playState = {
     cursors = game.input.keyboard.createCursorKeys();
 
     var labelOptions = { font: "30px Arial", fill: "#ffffff" };
-    labelScore = game.add.text(20, 20, 0, labelOptions);
+    scoreLabel = game.add.text(20, 20, 0, labelOptions);
   },
 
   update: function() {
@@ -49,7 +49,7 @@ var playState = {
 
   incrementPoints: function() {
     score += 1;
-    labelScore.text = score;
+    scoreLabel.text = score;
   },
 
   moveBall: function() {


### PR DESCRIPTION
Fix #1 

O erro acontecia por que não era setado que o `sprite` não obedecia os limites do mundo do jogo.

Pare arrumar, bastou adicionar o `sprite` ao sistema de colisão e depois setar que ela obedeca o limite. 
